### PR TITLE
Fixing .4% error rate.

### DIFF
--- a/src/serialdriver.cpp
+++ b/src/serialdriver.cpp
@@ -149,7 +149,7 @@ int SerialDriver::read(unsigned char *buf)
 		if(len > 256)
 		{
 			qDebug() << "Data length over 256 bytes (" << len << "bytes)";
-			len = 48;
+			len = 256;
 			USBSerialPort.clear((QSerialPort::AllDirections));
 			emit dataStatus(0, DATAIN_STATUS_RED);
 			return 0;

--- a/src/serialdriver.cpp
+++ b/src/serialdriver.cpp
@@ -149,7 +149,7 @@ int SerialDriver::read(unsigned char *buf)
 		if(len > 256)
 		{
 			qDebug() << "Data length over 256 bytes (" << len << "bytes)";
-			len = 256;
+			len = 48;
 			USBSerialPort.clear((QSerialPort::AllDirections));
 			emit dataStatus(0, DATAIN_STATUS_RED);
 			return 0;


### PR DESCRIPTION
This may not compile because of size_t being defined again. I didn't find a clean way that works on all compilers.. I think it's a windows/mac/arm issue. 